### PR TITLE
Fix country name display, data aliasing, and map label layering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Layout from "./components/Layout";
 import { useFilterStore } from "./store/useFilterStore";
 import { OUTCOME_COLORS } from "./lib/colors";
 import { buildChoroplethFillColor } from "./lib/riskColors";
-import { cowNameToGeoJsonAdmin } from "./lib/countryNameMapping";
+import { cowNameToGeoJsonAdmin, getDataLookupName, getCoHighlightNames } from "./lib/countryNameMapping";
 import {
   getCoupsFeatureCollection,
   getAllCoupEvents,
@@ -76,12 +76,15 @@ export default function App() {
       .catch((err) => console.error("Failed to load countries GeoJSON:", err));
   }, []);
 
-  // Predictions are now bundled locally — no async fetch needed
+  // Predictions are bundled locally — no async fetch needed
   const allPredictions = useMemo<CoupPrediction[]>(
     () => getPredictionFeatureCollection().features.map((f) => f.properties),
     [],
   );
-  const [selectedPrediction, setSelectedPrediction] = useState<CoupPrediction | null>(null);
+  const [selectedPrediction, setSelectedPrediction] =
+    useState<CoupPrediction | null>(null);
+  const [selectedPredictionDisplayName, setSelectedPredictionDisplayName] =
+    useState<string | null>(null);
 
   // Build choropleth fill-color expression for risk mode
   const choroplethFillColor = useMemo(() => {
@@ -92,6 +95,20 @@ export default function App() {
   const selectedEvent = useFilterStore((s) => s.selectedEvent);
   const setSelectedEvent = useFilterStore((s) => s.setSelectedEvent);
   const setSelectedCountry = useFilterStore((s) => s.setSelectedCountry);
+  const selectedGeoNames = useFilterStore((s) => s.selectedGeoNames);
+  const setSelectedGeoNames = useFilterStore((s) => s.setSelectedGeoNames);
+
+  // Sync selected country outlines to map feature state
+  const prevSelectedGeoNames = useRef<string[]>([]);
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+    if (!map || !mapLoaded) return;
+    for (const name of prevSelectedGeoNames.current)
+      map.setFeatureState({ source: "countries", id: name }, { selected: false });
+    for (const name of selectedGeoNames)
+      map.setFeatureState({ source: "countries", id: name }, { selected: true });
+    prevSelectedGeoNames.current = selectedGeoNames;
+  }, [selectedGeoNames, mapLoaded]);
   const searchQuery = useFilterStore((s) => s.searchQuery);
   const selectedOutcomes = useFilterStore((s) => s.selectedOutcomes);
   const selectedRegions = useFilterStore((s) => s.selectedRegions);
@@ -207,6 +224,7 @@ export default function App() {
         if (countryName) {
           setSelectedCountry(countryName);
           setSelectedEvent(null);
+          setSelectedGeoNames([countryName, ...getCoHighlightNames(countryName)]);
           return;
         }
       }
@@ -260,6 +278,7 @@ export default function App() {
         if (nearestCountry && minDistance < 15) {
           setSelectedCountry(nearestCountry);
           setSelectedEvent(null);
+          setSelectedGeoNames([nearestCountry, ...getCoHighlightNames(nearestCountry)]);
           return;
         }
       }
@@ -267,8 +286,9 @@ export default function App() {
       // No country or coup clicked
       setSelectedEvent(null);
       setSelectedCountry(null);
+      setSelectedGeoNames([]);
     },
-    [setSelectedEvent, setSelectedCountry, countriesGeoJSON],
+    [setSelectedEvent, setSelectedCountry, setSelectedGeoNames, countriesGeoJSON],
   );
 
   useClearSelectionOnMapClick({
@@ -285,8 +305,10 @@ export default function App() {
       setSelectedEvent(null);
     } else {
       setSelectedPrediction(null);
+      setSelectedPredictionDisplayName(null);
     }
-  }, [viewMode, setSelectedEvent, setSelectedPrediction]);
+    setSelectedGeoNames([]);
+  }, [viewMode, setSelectedEvent, setSelectedPrediction, setSelectedGeoNames]);
 
   return (
     <Layout mapRef={mapRef} allEvents={allEvents}>
@@ -319,18 +341,25 @@ export default function App() {
             if (!feature) {
               setSelectedEvent(null);
               setSelectedPrediction(null);
+              setSelectedPredictionDisplayName(null);
+              setSelectedGeoNames([]);
               return;
             }
 
             if (feature.layer.id === "countries-fill") {
               const geoName = feature.properties?.name;
               if (geoName) {
+                const cowLookup = getDataLookupName(geoName);
                 const pred = allPredictions.find(
                   (p) =>
-                    p.country === geoName ||
-                    cowNameToGeoJsonAdmin(p.country) === geoName,
+                    p.country === cowLookup ||
+                    cowNameToGeoJsonAdmin(p.country) === cowLookup,
                 );
-                if (pred) setSelectedPrediction(pred);
+                if (pred) {
+                  setSelectedPrediction(pred);
+                  setSelectedPredictionDisplayName(geoName);
+                  setSelectedGeoNames([geoName, ...getCoHighlightNames(geoName)]);
+                }
               }
             }
           }}
@@ -347,6 +376,7 @@ export default function App() {
               <Layer
                 id="countries-fill"
                 type="fill"
+                beforeId="waterway_label"
                 paint={{
                   "fill-color":
                     viewMode === "risk" && choroplethFillColor
@@ -358,6 +388,7 @@ export default function App() {
               <Layer
                 id="countries-outline"
                 type="line"
+                beforeId="waterway_label"
                 paint={{
                   "line-color": "#334155",
                   "line-width": 0.5,
@@ -366,12 +397,27 @@ export default function App() {
               <Layer
                 id="countries-hover-outline"
                 type="line"
+                beforeId="waterway_label"
                 paint={{
                   "line-color": "#e2e8f0",
                   "line-width": [
                     "case",
                     ["boolean", ["feature-state", "hover"], false],
                     2,
+                    0,
+                  ] as any,
+                }}
+              />
+              <Layer
+                id="countries-selected-outline"
+                type="line"
+                beforeId="waterway_label"
+                paint={{
+                  "line-color": "#f59e0b",
+                  "line-width": [
+                    "case",
+                    ["boolean", ["feature-state", "selected"], false],
+                    2.5,
                     0,
                   ] as any,
                 }}
@@ -399,6 +445,7 @@ export default function App() {
               onClose={() => {
                 setSelectedEvent(null);
                 setSelectedCountry(null);
+                setSelectedGeoNames([]);
               }}
               closeButton
               closeOnClick={false}
@@ -408,17 +455,24 @@ export default function App() {
                 onNavigateToNarrative={() => {
                   setSelectedEvent(null);
                   setSelectedCountry(null);
+                  setSelectedGeoNames([]);
                 }}
               />
             </Popup>
           )}
         </Map>
 
-      <PredictionPanel
-        prediction={selectedPrediction}
-        onClose={() => setSelectedPrediction(null)}
-      />
-      {viewMode === "events" ? <MapLegend /> : <RiskMapLegend />}
-    </div>
-  </Layout>
-)};
+        <PredictionPanel
+          prediction={selectedPrediction}
+          displayName={selectedPredictionDisplayName ?? undefined}
+          onClose={() => {
+            setSelectedPrediction(null);
+            setSelectedPredictionDisplayName(null);
+            setSelectedGeoNames([]);
+          }}
+        />
+        {viewMode === "events" ? <MapLegend /> : <RiskMapLegend />}
+      </div>
+    </Layout>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,6 +7,7 @@ import Toolbar from "./Toolbar";
 import EventsPanel from "./EventsPanel";
 import CountryPanel from "./CountryPanel";
 import { useFilterStore } from "../store/useFilterStore";
+import { getDataLookupName } from "../lib/countryNameMapping";
 import FiltersPanel from "./FiltersPanel";
 
 export interface LayoutProps {
@@ -19,6 +20,7 @@ export default function Layout({ children, mapRef, allEvents }: LayoutProps) {
   const [activeNav, setActiveNav] = useState<NavId>("home");
   const selectedCountry = useFilterStore((s) => s.selectedCountry);
   const setSelectedCountry = useFilterStore((s) => s.setSelectedCountry);
+  const setSelectedGeoNames = useFilterStore((s) => s.setSelectedGeoNames);
 
   const regions = useMemo(
     () => [...new Set(allEvents.map((event) => event.region))].sort(),
@@ -30,10 +32,11 @@ export default function Layout({ children, mapRef, allEvents }: LayoutProps) {
     [allEvents]
   );
 
-  const countryEvents = useMemo(
-    () => allEvents.filter((event) => event.country === selectedCountry),
-    [allEvents, selectedCountry]
-  );
+  const countryEvents = useMemo(() => {
+    if (!selectedCountry) return [];
+    const cowLookup = getDataLookupName(selectedCountry);
+    return allEvents.filter((event) => event.country === cowLookup);
+  }, [allEvents, selectedCountry]);
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden md:flex-row">
@@ -51,7 +54,7 @@ export default function Layout({ children, mapRef, allEvents }: LayoutProps) {
               <CountryPanel
                 country={selectedCountry}
                 events={countryEvents}
-                onClose={() => setSelectedCountry(null)}
+                onClose={() => { setSelectedCountry(null); setSelectedGeoNames([]); }}
               />
             </div>
           )}

--- a/src/components/PredictionPanel.tsx
+++ b/src/components/PredictionPanel.tsx
@@ -19,6 +19,7 @@ function safeFmt(value: unknown, decimals = 3): string {
 
 interface Props {
   prediction: CoupPrediction | null;
+  displayName?: string;
   onClose: () => void;
 }
 
@@ -105,7 +106,7 @@ function StatRow({
     }
 }
 
-export default function PredictionPanel({ prediction, onClose }: Props) {
+export default function PredictionPanel({ prediction, displayName, onClose }: Props) {
   if (!prediction) return null;
 
   const prob = prediction.yhat;
@@ -133,7 +134,7 @@ export default function PredictionPanel({ prediction, onClose }: Props) {
       {/* Header */}
       <div className="flex items-start justify-between p-4 border-b border-gray-800">
         <div>
-          <h2 className="font-bold text-white text-xl">{prediction.country}</h2>
+          <h2 className="font-bold text-white text-xl">{displayName ?? prediction.country}</h2>
           <p className="text-gray-400 text-xs mt-0.5">
             {prediction.year} · Month {prediction.month}
           </p>

--- a/src/lib/countryNameMapping.ts
+++ b/src/lib/countryNameMapping.ts
@@ -8,6 +8,7 @@
 const COW_TO_GEOJSON: Record<string, string> = {
   "Antigua & Barbuda": "Antigua and Barbuda",
   "Bahamas": "The Bahamas",
+  "Cape Verde": "Cabo Verde",
   "Congo": "Republic of the Congo",
   "Czech Republic": "Czechia",
   "East Timor": "East Timor",
@@ -19,6 +20,7 @@ const COW_TO_GEOJSON: Record<string, string> = {
   "Swaziland": "eSwatini",
   "Tanzania": "United Republic of Tanzania",
   "United States": "United States of America",
+  "Yugoslavia": "Republic of Serbia",
 };
 
 /**
@@ -27,4 +29,31 @@ const COW_TO_GEOJSON: Record<string, string> = {
  */
 export function cowNameToGeoJsonAdmin(cowName: string): string {
   return COW_TO_GEOJSON[cowName] ?? cowName;
+}
+
+/**
+ * Maps a clicked GeoJSON country name to the COW data name whose data should be shown.
+ * Used when a territory (Greenland) or renamed country (Serbia, Cabo Verde) is clicked.
+ */
+const GEOJSON_TO_COW_DATA: Record<string, string> = {
+  "Greenland":          "Denmark",
+  "Republic of Serbia": "Yugoslavia",
+  "Cabo Verde":         "Cape Verde",
+};
+
+export function getDataLookupName(geoName: string): string {
+  return GEOJSON_TO_COW_DATA[geoName] ?? geoName;
+}
+
+/**
+ * Returns additional GeoJSON country names that should be co-highlighted
+ * when the given country is selected (e.g. Greenland ↔ Denmark).
+ */
+const CO_HIGHLIGHT_PAIRS: Record<string, string[]> = {
+  "Greenland": ["Denmark"],
+  "Denmark":   ["Greenland"],
+};
+
+export function getCoHighlightNames(geoName: string): string[] {
+  return CO_HIGHLIGHT_PAIRS[geoName] ?? [];
 }

--- a/src/lib/riskColors.ts
+++ b/src/lib/riskColors.ts
@@ -90,6 +90,12 @@ export function buildChoroplethFillColor(
     }
   }
 
+  // Greenland has no COW entry — color it the same as Denmark
+  const dkPred = latest.get("Denmark");
+  if (dkPred && !latest.has("Greenland")) {
+    latest.set("Greenland", dkPred);
+  }
+
   // Find max probability to normalize the color scale.
   // Raw values are tiny (0–0.06), so without normalization everything looks gray.
   const maxProb = Math.max(...[...latest.values()].map((p) => p.yhat), 0.001);

--- a/src/store/useFilterStore.ts
+++ b/src/store/useFilterStore.ts
@@ -10,6 +10,7 @@ export interface FilterState {
   selectedTags: string[];
   selectedEvent: CoupEvent | null;
   selectedCountry: string | null;
+  selectedGeoNames: string[];
   yearRange: [number, number];
   viewMode: "events" | "risk";
 
@@ -23,6 +24,7 @@ export interface FilterState {
   reset: () => void;
   setSelectedEvent: (event: CoupEvent | null) => void;
   setSelectedCountry: (country: string | null) => void;
+  setSelectedGeoNames: (names: string[]) => void;
   setViewMode: (mode: "events" | "risk") => void;
 }
 
@@ -44,6 +46,7 @@ export const useFilterStore = create<FilterState>((set) => ({
   selectedTags: [],
   selectedEvent: null,
   selectedCountry: null,
+  selectedGeoNames: [],
   yearRange: [1950, 2026],
   viewMode: "events",
 
@@ -88,9 +91,11 @@ export const useFilterStore = create<FilterState>((set) => ({
       selectedTags: [],
       selectedEvent: null,
       selectedCountry: null,
+      selectedGeoNames: [],
       yearRange: [1950, 2026],
     }),
   setViewMode: (mode) => set({ viewMode: mode }),
   setSelectedEvent: (event) => set({ selectedEvent: event }),
   setSelectedCountry: (country) => set({ selectedCountry: country }),
+  setSelectedGeoNames: (names) => set({ selectedGeoNames: names }),
 }))


### PR DESCRIPTION
Closes #33

- Serbia and Cabo Verde now appear correctly colored on the risk choropleth by mapping their COW dataset names (Yugoslavia, Cape Verde) to their GeoJSON names
- Clicking Greenland or Denmark highlights both countries simultaneously and shows Denmark's data; clicking Serbia or Cabo Verde shows their GeoJSON display name while pulling the correct underlying data
- Base map text labels no longer get discolored or obscured by the country fill/outline layers