### PR TITLE
Events heatmap: filter support, label layering, and outline polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { type CoupEvent, type CoupPrediction } from "./types/coup";
 import PredictionPanel from "./components/PredictionPanel";
 import EventPopup from "./components/EventPopup";
 import MapLegend from "./components/MapLegend";
+import EventsHeatmapLegend from "./components/EventsHeatmapLegend";
 import Layout from "./components/Layout";
 import { useFilterStore } from "./store/useFilterStore";
 import { OUTCOME_COLORS, PREDICTION_NULL_COLOR } from "./lib/colors";
@@ -24,6 +25,7 @@ import { buildYhatPredictionProbMap } from "./lib/yhatPredictions";
 import { buildMapFilterExpression } from "./lib/filterHelpers";
 import { computeRiskThresholds, getRiskBucketBounds } from "./lib/riskBuckets";
 import { getDataLookupName, getCoHighlightNames } from "./lib/countryNameMapping";
+import { buildEventCountChoropleth, getMaxEventCount } from "./lib/riskColors";
 import { useMapHover } from "./hooks/useMapHover";
 import { useEscapeToClearSelection } from "./hooks/useEscapeToClearSelection";
 import { useClearSelectionOnMapClick } from "./hooks/useClearSelectionOnMapClick";
@@ -500,6 +502,7 @@ export default function App() {
     [riskThresholds],
   );
 
+<<<<<<< HEAD
   // Sync selected country outlines to map feature state
   useEffect(() => {
     const map = mapRef.current?.getMap();
@@ -510,6 +513,17 @@ export default function App() {
       map.setFeatureState({ source: "countries", id: name }, { selected: true });
     prevSelectedGeoNames.current = selectedGeoNames;
   }, [selectedGeoNames, mapLoaded]);
+=======
+  const eventChoroplethFillColor = useMemo(() => {
+    if (viewMode !== "events") return null;
+    return buildEventCountChoropleth(filteredEvents);
+  }, [viewMode, filteredEvents]);
+
+  const eventMaxCount = useMemo(() => {
+    if (viewMode !== "events") return 0;
+    return getMaxEventCount(filteredEvents);
+  }, [viewMode, filteredEvents]);
+>>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
 
   useEffect(() => {
     if (viewMode === "events") {
@@ -678,7 +692,7 @@ export default function App() {
 
   useClearSelectionOnMapClick({
     mapRef,
-    layerIds: viewMode === "events" ? ["coup-circles"] : [],
+    layerIds: [],
     setSelectedEvent,
   });
 
@@ -746,8 +760,13 @@ export default function App() {
           mapStyle={MAP_STYLE}
           interactiveLayerIds={
             viewMode === "events"
+<<<<<<< HEAD
               ? ["coup-circles", "countries-fill"]
               : ["country-risk-fill", "countries-fill"]
+=======
+              ? ["countries-fill"]
+              : ["country-risk-fill"]
+>>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
           }
           onMouseEnter={onMouseEnter}
           onMouseMove={onMouseMove}
@@ -755,7 +774,10 @@ export default function App() {
           onClick={(e) => {
             const features = e.features ?? [];
 
-            if (features.some((f) => f.layer?.id === "coup-circles")) {
+            if (
+              features.some((f) => f.layer?.id === "coup-circles") ||
+              features.some((f) => f.layer?.id === "countries-fill")
+            ) {
               onClick(e);
             } else if (features.some((f) => f.layer?.id === "country-risk-fill")) {
               const f = features.find((item) => item.layer?.id === "country-risk-fill");
@@ -775,6 +797,7 @@ export default function App() {
           }}
           onLoad={() => setMapLoaded(true)}
         >
+<<<<<<< HEAD
           {viewMode === "events" && (
             <Source
               id="coups"
@@ -793,6 +816,17 @@ export default function App() {
                 type="fill"
                 beforeId="waterway_label"
                 paint={{ "fill-color": "rgba(0,0,0,0)", "fill-opacity": 0 }}
+=======
+          {viewMode === "events" && countriesGeoJSON && (
+            <Source id="countries" type="geojson" data={countriesGeoJSON}>
+              <Layer
+                id="countries-fill"
+                type="fill"
+                paint={{
+                  "fill-color": eventChoroplethFillColor ?? "rgba(0,0,0,0)",
+                  "fill-opacity": eventChoroplethFillColor ? 0.65 : 0,
+                }}
+>>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
               />
               <Layer
                 id="countries-outline"
@@ -878,7 +912,9 @@ export default function App() {
           monthsLabel={viewMode === "forecast" ? monthsAhead : futureMonths}
         />
 
-        <MapLegend riskBucketBounds={riskBucketBounds} />
+        {viewMode === "events"
+          ? <EventsHeatmapLegend maxCount={eventMaxCount} />
+          : <MapLegend riskBucketBounds={riskBucketBounds} />}
       </div>
     </Layout>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useRef, useState, useCallback, useMemo, useEffect } from "react";
 import { css } from "styled-system/css";
 import { Map, Source, Layer, Popup, type MapRef } from "@vis.gl/react-maplibre";
 import type {
-  CircleLayerSpecification,
   FillLayerSpecification,
   MapLayerMouseEvent,
 } from "maplibre-gl";
@@ -13,19 +12,18 @@ import MapLegend from "./components/MapLegend";
 import EventsHeatmapLegend from "./components/EventsHeatmapLegend";
 import Layout from "./components/Layout";
 import { useFilterStore } from "./store/useFilterStore";
-import { OUTCOME_COLORS, PREDICTION_NULL_COLOR } from "./lib/colors";
+import { PREDICTION_NULL_COLOR } from "./lib/colors";
 import {
-  getCoupsFeatureCollection,
   getAllCoupEvents,
   getPredictionFeatureCollection,
   buildPredictionProbMap,
   COW_TO_ADMIN_ALIASES,
 } from "./lib/coupData";
 import { buildYhatPredictionProbMap } from "./lib/yhatPredictions";
-import { buildMapFilterExpression } from "./lib/filterHelpers";
 import { computeRiskThresholds, getRiskBucketBounds } from "./lib/riskBuckets";
 import { getDataLookupName, getCoHighlightNames } from "./lib/countryNameMapping";
 import { buildEventCountChoropleth, getMaxEventCount } from "./lib/riskColors";
+import { filterEvents } from "./lib/filterHelpers";
 import { useMapHover } from "./hooks/useMapHover";
 import { useEscapeToClearSelection } from "./hooks/useEscapeToClearSelection";
 import { useClearSelectionOnMapClick } from "./hooks/useClearSelectionOnMapClick";
@@ -41,32 +39,6 @@ import {
 const MAP_STYLE =
   "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
-const circleLayerPaint: CircleLayerSpecification["paint"] = {
-  "circle-radius": [
-    "case",
-    ["boolean", ["feature-state", "hover"], false],
-    14,
-    10,
-  ],
-  "circle-color": [
-    "match",
-    ["get", "outcome"],
-    "successful",
-    OUTCOME_COLORS.successful,
-    "failed",
-    OUTCOME_COLORS.failed,
-    "attempted",
-    OUTCOME_COLORS.attempted,
-    "plot",
-    OUTCOME_COLORS.plot,
-    "alleged",
-    OUTCOME_COLORS.alleged,
-    OUTCOME_COLORS.alleged,
-  ],
-  "circle-stroke-width": 2,
-  "circle-stroke-color": "#FFFFFF",
-  "circle-opacity": 1,
-};
 
 function buildCountryHeatmapLayerStyle(
   moderateMin: number,
@@ -224,6 +196,10 @@ export default function App() {
   const allEvents = useMemo(() => getAllCoupEvents(), []);
   const yearRange = useFilterStore((s) => s.yearRange);
   const viewMode = useFilterStore((s) => s.viewMode);
+  const searchQuery = useFilterStore((s) => s.searchQuery);
+  const selectedOutcomes = useFilterStore((s) => s.selectedOutcomes);
+  const selectedRegions = useFilterStore((s) => s.selectedRegions);
+  const selectedTags = useFilterStore((s) => s.selectedTags);
 
   const selectedEvent = useFilterStore((s) => s.selectedEvent);
   const setSelectedEvent = useFilterStore((s) => s.setSelectedEvent);
@@ -231,17 +207,16 @@ export default function App() {
   const setSelectedCountry = useFilterStore((s) => s.setSelectedCountry);
   const selectedGeoNames = useFilterStore((s) => s.selectedGeoNames);
   const setSelectedGeoNames = useFilterStore((s) => s.setSelectedGeoNames);
-  const searchQuery = useFilterStore((s) => s.searchQuery);
-  const selectedOutcomes = useFilterStore((s) => s.selectedOutcomes);
-  const selectedRegions = useFilterStore((s) => s.selectedRegions);
-  const dateRange = useFilterStore((s) => s.dateRange);
-  const selectedTags = useFilterStore((s) => s.selectedTags);
 
   const filteredEvents = useMemo(() => {
-    return allEvents.filter((event) => {
-      return event.year >= yearRange[0] && event.year <= yearRange[1];
+    return filterEvents(allEvents, {
+      searchQuery,
+      selectedOutcomes,
+      selectedRegions,
+      selectedTags,
+      dateRange: yearRange,
     });
-  }, [allEvents, yearRange]);
+  }, [allEvents, yearRange, searchQuery, selectedOutcomes, selectedRegions, selectedTags]);
 
   const [predictiveEnabled, setPredictiveEnabled] = useState(false);
   const [predictiveMode, setPredictiveMode] =
@@ -502,7 +477,6 @@ export default function App() {
     [riskThresholds],
   );
 
-<<<<<<< HEAD
   // Sync selected country outlines to map feature state
   useEffect(() => {
     const map = mapRef.current?.getMap();
@@ -513,7 +487,7 @@ export default function App() {
       map.setFeatureState({ source: "countries", id: name }, { selected: true });
     prevSelectedGeoNames.current = selectedGeoNames;
   }, [selectedGeoNames, mapLoaded]);
-=======
+
   const eventChoroplethFillColor = useMemo(() => {
     if (viewMode !== "events") return null;
     return buildEventCountChoropleth(filteredEvents);
@@ -523,7 +497,6 @@ export default function App() {
     if (viewMode !== "events") return 0;
     return getMaxEventCount(filteredEvents);
   }, [viewMode, filteredEvents]);
->>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
 
   useEffect(() => {
     if (viewMode === "events") {
@@ -534,36 +507,6 @@ export default function App() {
     }
     setSelectedGeoNames([]);
   }, [viewMode, setSelectedEvent, setSelectedCountry, setSelectedGeoNames]);
-
-  const filterExpression = useMemo(
-    () =>
-      buildMapFilterExpression(
-        {
-          searchQuery,
-          selectedOutcomes,
-          selectedRegions,
-          dateRange,
-          selectedTags,
-        },
-        allEvents,
-      ),
-    [
-      searchQuery,
-      selectedOutcomes,
-      selectedRegions,
-      dateRange,
-      selectedTags,
-      allEvents,
-    ],
-  );
-
-  const circleLayerStyle: CircleLayerSpecification = {
-    id: "coup-circles",
-    type: "circle",
-    source: "coups",
-    paint: circleLayerPaint,
-    filter: filterExpression,
-  };
 
   const { onMouseEnter, onMouseLeave } = useMapHover({
     mapRef,
@@ -760,13 +703,8 @@ export default function App() {
           mapStyle={MAP_STYLE}
           interactiveLayerIds={
             viewMode === "events"
-<<<<<<< HEAD
-              ? ["coup-circles", "countries-fill"]
-              : ["country-risk-fill", "countries-fill"]
-=======
               ? ["countries-fill"]
-              : ["country-risk-fill"]
->>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
+              : ["country-risk-fill", "countries-fill"]
           }
           onMouseEnter={onMouseEnter}
           onMouseMove={onMouseMove}
@@ -776,18 +714,20 @@ export default function App() {
 
             if (
               features.some((f) => f.layer?.id === "coup-circles") ||
-              features.some((f) => f.layer?.id === "countries-fill")
+              (viewMode === "events" && features.some((f) => f.layer?.id === "countries-fill"))
             ) {
               onClick(e);
             } else if (features.some((f) => f.layer?.id === "country-risk-fill")) {
               const f = features.find((item) => item.layer?.id === "country-risk-fill");
-              const countryName =
-                f?.properties?.ADMIN ?? f?.properties?.name ?? null;
+              const adminName = f?.properties?.ADMIN ?? null;
+              const geoName = f?.properties?.name ?? null;
+              const countryName = adminName ?? geoName;
+              const geoNames = [...new Set([adminName, geoName].filter(Boolean) as string[])];
 
               setSelectedEvent(null);
               setSelectedCountry(null);
               setSelectedRiskCountry(countryName);
-              setSelectedGeoNames(countryName ? [countryName, ...getCoHighlightNames(countryName)] : []);
+              setSelectedGeoNames(countryName ? [...geoNames, ...getCoHighlightNames(countryName)] : []);
             } else {
               setSelectedEvent(null);
               setSelectedCountry(null);
@@ -797,53 +737,34 @@ export default function App() {
           }}
           onLoad={() => setMapLoaded(true)}
         >
-<<<<<<< HEAD
-          {viewMode === "events" && (
-            <Source
-              id="coups"
-              type="geojson"
-              data={getCoupsFeatureCollection(filteredEvents)}
-              promoteId="id"
-            >
-              <Layer {...circleLayerStyle} />
-            </Source>
-          )}
-
           {countriesGeoJSON && (
             <Source id="countries" type="geojson" data={countriesGeoJSON} promoteId="name">
               <Layer
                 id="countries-fill"
                 type="fill"
                 beforeId="waterway_label"
-                paint={{ "fill-color": "rgba(0,0,0,0)", "fill-opacity": 0 }}
-=======
-          {viewMode === "events" && countriesGeoJSON && (
-            <Source id="countries" type="geojson" data={countriesGeoJSON}>
-              <Layer
-                id="countries-fill"
-                type="fill"
                 paint={{
-                  "fill-color": eventChoroplethFillColor ?? "rgba(0,0,0,0)",
-                  "fill-opacity": eventChoroplethFillColor ? 0.65 : 0,
+                  "fill-color": (viewMode === "events" && eventChoroplethFillColor
+                    ? eventChoroplethFillColor
+                    : "rgba(0,0,0,0)") as any,
+                  "fill-opacity": viewMode === "events" && eventChoroplethFillColor ? 0.65 : 0,
                 }}
->>>>>>> c86b791 (Add events heatmap choropleth with green-red color scale)
               />
               <Layer
                 id="countries-outline"
                 type="line"
                 beforeId="waterway_label"
-                paint={{ "line-color": "#334155", "line-width": 0.5 }}
+                paint={{ "line-color": "#ffffff", "line-width": 0.5 }}
               />
               <Layer
                 id="countries-hover-outline"
                 type="line"
-                beforeId="waterway_label"
                 paint={{
-                  "line-color": "#e2e8f0",
+                  "line-color": "#ffffff",
                   "line-width": [
                     "case",
                     ["boolean", ["feature-state", "hover"], false],
-                    2,
+                    2.5,
                     0,
                   ] as any,
                 }}
@@ -851,13 +772,12 @@ export default function App() {
               <Layer
                 id="countries-selected-outline"
                 type="line"
-                beforeId="waterway_label"
                 paint={{
-                  "line-color": "#f59e0b",
+                  "line-color": "#000000",
                   "line-width": [
                     "case",
                     ["boolean", ["feature-state", "selected"], false],
-                    2.5,
+                    3,
                     0,
                   ] as any,
                 }}
@@ -867,7 +787,7 @@ export default function App() {
 
           {viewMode === "risk" && riskCountriesGeoJSON && (
             <Source id="country-risk" type="geojson" data={riskCountriesGeoJSON}>
-              <Layer {...countryHeatmapLayerStyle} />
+              <Layer {...countryHeatmapLayerStyle} beforeId="waterway_label" />
             </Source>
           )}
 
@@ -877,7 +797,7 @@ export default function App() {
               type="geojson"
               data={forecastCountriesGeoJSON}
             >
-              <Layer {...countryHeatmapLayerStyle} />
+              <Layer {...countryHeatmapLayerStyle} beforeId="waterway_label" />
             </Source>
           )}
 
@@ -896,7 +816,7 @@ export default function App() {
 
         <PredictionPanel
           prediction={selectedPrediction}
-          displayName={selectedRiskCountry ?? undefined}
+
           riskThresholds={riskThresholds}
           onClose={() => { setSelectedRiskCountry(null); setSelectedGeoNames([]); }}
           predictiveEnabled={predictiveEnabled}

--- a/src/components/EventsHeatmapLegend.tsx
+++ b/src/components/EventsHeatmapLegend.tsx
@@ -1,7 +1,13 @@
 import { css } from "styled-system/css";
+import { predictionColors } from "../design-system/tokens";
 import { EVENT_NO_DATA_COLOR } from "../lib/riskColors";
 
-const GRADIENT_STOPS = ["#22c55e", "#eab308", "#f97316", "#ef4444"];
+const GRADIENT_STOPS = [
+  predictionColors.veryLow,
+  predictionColors.moderate,
+  predictionColors.elevated,
+  predictionColors.high,
+];
 
 interface EventsHeatmapLegendProps {
   maxCount: number;
@@ -51,37 +57,21 @@ const swatchStyle = css({
   borderColor: "var(--colors-border-strong)",
 });
 
-export default function EventsHeatmapLegend({ maxCount }: EventsHeatmapLegendProps) {
-  const gradientCSS = `linear-gradient(to right, ${GRADIENT_STOPS.join(", ")})`;
+const BUCKET_LABELS = ["Very Low", "Moderate", "Elevated", "High"];
 
+export default function EventsHeatmapLegend({ maxCount }: EventsHeatmapLegendProps) {
   return (
     <div className={legendStyle}>
-      <div className={labelStyle}>Coup Event Frequency</div>
-      <div className={css({ display: "flex", flexDirection: "column", gap: "1.5" })}>
-        <div
-          className={css({
-            width: "full",
-            height: "3",
-            borderRadius: "sm",
-            borderWidth: "1px",
-            borderStyle: "solid",
-            borderColor: "var(--colors-border-strong)",
-          })}
-          style={{ background: gradientCSS }}
-        />
-        <div
-          className={css({
-            display: "flex",
-            justifyContent: "space-between",
-            fontSize: "xs",
-            color: "var(--colors-text-secondary)",
-          })}
-        >
-          <span>Fewer</span>
-          <span>More</span>
-        </div>
+      <div className={labelStyle}>Historical Coup Activity</div>
+      <div className={css({ display: "flex", flexDirection: "column", gap: "1" })}>
+        {GRADIENT_STOPS.map((color, i) => (
+          <div key={color} className={rowStyle}>
+            <span className={swatchStyle} style={{ backgroundColor: color }} />
+            {BUCKET_LABELS[i]}
+          </div>
+        ))}
         {maxCount > 0 && (
-          <div className={css({ fontSize: "xs", color: "var(--colors-text-muted)", fontStyle: "italic" })}>
+          <div className={css({ fontSize: "xs", color: "var(--colors-text-muted)", fontStyle: "italic", marginTop: "1" })}>
             Highest: {maxCount} events
           </div>
         )}

--- a/src/components/EventsHeatmapLegend.tsx
+++ b/src/components/EventsHeatmapLegend.tsx
@@ -1,0 +1,95 @@
+import { css } from "styled-system/css";
+import { EVENT_NO_DATA_COLOR } from "../lib/riskColors";
+
+const GRADIENT_STOPS = ["#22c55e", "#eab308", "#f97316", "#ef4444"];
+
+interface EventsHeatmapLegendProps {
+  maxCount: number;
+}
+
+const legendStyle = css({
+  position: "absolute",
+  bottom: "20",
+  left: "max(1rem, env(safe-area-inset-left))",
+  zIndex: "10",
+  borderRadius: "lg",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "var(--colors-border-default)",
+  backgroundColor:
+    "color-mix(in srgb, var(--colors-bg-panel) 92%, var(--colors-bg-muted))",
+  paddingInline: "3.5",
+  paddingBlock: "2.5",
+  boxShadow: "0 8px 22px color-mix(in srgb, #000 12%, transparent)",
+  backdropFilter: "blur(8px)",
+  md: { bottom: "4", left: "4" },
+});
+
+const labelStyle = css({
+  marginBottom: "2",
+  fontSize: "xs",
+  fontWeight: "semibold",
+  color: "var(--colors-text-muted)",
+});
+
+const rowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2.5",
+  fontSize: "xs",
+  color: "var(--colors-text-secondary)",
+  lineHeight: "1.35",
+});
+
+const swatchStyle = css({
+  height: "3",
+  width: "3",
+  flexShrink: "0",
+  borderRadius: "sm",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "var(--colors-border-strong)",
+});
+
+export default function EventsHeatmapLegend({ maxCount }: EventsHeatmapLegendProps) {
+  const gradientCSS = `linear-gradient(to right, ${GRADIENT_STOPS.join(", ")})`;
+
+  return (
+    <div className={legendStyle}>
+      <div className={labelStyle}>Coup Event Frequency</div>
+      <div className={css({ display: "flex", flexDirection: "column", gap: "1.5" })}>
+        <div
+          className={css({
+            width: "full",
+            height: "3",
+            borderRadius: "sm",
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderColor: "var(--colors-border-strong)",
+          })}
+          style={{ background: gradientCSS }}
+        />
+        <div
+          className={css({
+            display: "flex",
+            justifyContent: "space-between",
+            fontSize: "xs",
+            color: "var(--colors-text-secondary)",
+          })}
+        >
+          <span>Fewer</span>
+          <span>More</span>
+        </div>
+        {maxCount > 0 && (
+          <div className={css({ fontSize: "xs", color: "var(--colors-text-muted)", fontStyle: "italic" })}>
+            Highest: {maxCount} events
+          </div>
+        )}
+        <div className={rowStyle}>
+          <span className={swatchStyle} style={{ backgroundColor: EVENT_NO_DATA_COLOR }} />
+          No events
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/riskColors.ts
+++ b/src/lib/riskColors.ts
@@ -114,3 +114,52 @@ export function buildChoroplethFillColor(
 
   return ["match", ["get", "name"], ...entries, NO_DATA_COLOR];
 }
+
+import type { CoupEvent } from "../types/coup";
+
+function eventScoreToColor(score: number): string {
+  const clamped = Math.max(0, Math.min(1, score));
+
+  const stops: [number, number, number][] = [
+    [0x22, 0xc5, 0x5e], // #22c55e green-500
+    [0xea, 0xb3, 0x08], // #eab308 yellow-500
+    [0xf9, 0x73, 0x16], // #f97316 orange-500
+    [0xef, 0x44, 0x44], // #ef4444 red-500
+  ];
+
+  const seg = clamped * (stops.length - 1);
+  const lo = Math.min(Math.floor(seg), stops.length - 2);
+  const t = seg - lo;
+  const [r1, g1, b1] = stops[lo];
+  const [r2, g2, b2] = stops[lo + 1];
+
+  const r = Math.round(r1 + (r2 - r1) * t);
+  const g = Math.round(g1 + (g2 - g1) * t);
+  const b = Math.round(b1 + (b2 - b1) * t);
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+export const EVENT_NO_DATA_COLOR = "#e5e7eb"; // gray-200 — neutral on the light map
+
+export function buildEventCountChoropleth(events: CoupEvent[]): any[] {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const geoName = cowNameToGeoJsonAdmin(e.country);
+    counts.set(geoName, (counts.get(geoName) ?? 0) + 1);
+  }
+  const maxCount = Math.max(...counts.values(), 1);
+  const entries: string[] = [];
+  for (const [geoName, count] of counts) {
+    entries.push(geoName, eventScoreToColor(count / maxCount));
+  }
+  return ["match", ["get", "name"], ...entries, EVENT_NO_DATA_COLOR];
+}
+
+export function getMaxEventCount(events: CoupEvent[]): number {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const geoName = cowNameToGeoJsonAdmin(e.country);
+    counts.set(geoName, (counts.get(geoName) ?? 0) + 1);
+  }
+  return counts.size === 0 ? 0 : Math.max(...counts.values());
+}

--- a/src/lib/riskColors.ts
+++ b/src/lib/riskColors.ts
@@ -116,30 +116,23 @@ export function buildChoroplethFillColor(
 }
 
 import type { CoupEvent } from "../types/coup";
+import { predictionColors, neutral } from "../design-system/tokens";
+
+export const EVENT_NO_DATA_COLOR = neutral[500]; // matches PREDICTION_NULL_COLOR
+
+const EVENT_COLOR_STOPS = [
+  predictionColors.veryLow,
+  predictionColors.moderate,
+  predictionColors.elevated,
+  predictionColors.high,
+];
 
 function eventScoreToColor(score: number): string {
-  const clamped = Math.max(0, Math.min(1, score));
-
-  const stops: [number, number, number][] = [
-    [0x22, 0xc5, 0x5e], // #22c55e green-500
-    [0xea, 0xb3, 0x08], // #eab308 yellow-500
-    [0xf9, 0x73, 0x16], // #f97316 orange-500
-    [0xef, 0x44, 0x44], // #ef4444 red-500
-  ];
-
-  const seg = clamped * (stops.length - 1);
-  const lo = Math.min(Math.floor(seg), stops.length - 2);
-  const t = seg - lo;
-  const [r1, g1, b1] = stops[lo];
-  const [r2, g2, b2] = stops[lo + 1];
-
-  const r = Math.round(r1 + (r2 - r1) * t);
-  const g = Math.round(g1 + (g2 - g1) * t);
-  const b = Math.round(b1 + (b2 - b1) * t);
-  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+  if (score < 0.25) return EVENT_COLOR_STOPS[0];
+  if (score < 0.5)  return EVENT_COLOR_STOPS[1];
+  if (score < 0.75) return EVENT_COLOR_STOPS[2];
+  return EVENT_COLOR_STOPS[3];
 }
-
-export const EVENT_NO_DATA_COLOR = "#e5e7eb"; // gray-200 — neutral on the light map
 
 export function buildEventCountChoropleth(events: CoupEvent[]): any[] {
   const counts = new Map<string, number>();


### PR DESCRIPTION
## Summary

- Heatmap choropleth now responds to all active filters (search, outcomes, regions, tags) — closes #40
- Fixed map labels being covered by fill layers by adding `beforeId="waterway_label"` to risk/forecast layers
- Fixed country hover/selected outlines being partially overridden by base map borders (removed `beforeId` from outline layers so they render on top)
- Fixed selected outline not appearing on some countries in risk view due to `ADMIN` vs `name` property mismatch
- Updated legend title from "Coup Event Frequency" to "Historical Coup Activity" with discrete bucket labels

## Test plan

- [ ] Switch to Events view — heatmap should show coup activity by country
- [ ] Toggle outcome, region, and tag filters — heatmap should update accordingly
- [ ] Adjust the year range slider — heatmap should update
- [ ] Switch to Risk and Forecast views — country names/labels should be visible above the fill layer
- [ ] Hover over a country — white outline should appear on all views
- [ ] Click a country — black outline should appear and persist
- [ ] Verify legend reads "Historical Coup Activity" with Very Low / Moderate / Elevated / High labels